### PR TITLE
Fix stacked areas overflow on null values when connectNulls is true

### DIFF
--- a/src/chart/line/helper.ts
+++ b/src/chart/line/helper.ts
@@ -121,9 +121,6 @@ export function getStackedOnPoint(
     if (dataCoordInfo.stacked) {
         value = data.get(data.getCalculationInfo('stackedOverDimension'), idx) as number;
     }
-    if (isNaN(value)) {
-        value = dataCoordInfo.valueStart;
-    }
 
     const baseDataOffset = dataCoordInfo.baseDataOffset;
     const stackedData = [];

--- a/src/processor/dataStack.ts
+++ b/src/processor/dataStack.ts
@@ -89,6 +89,9 @@ function calculateStack(stackInfoList: StackInfo[]) {
         const isStackedByIndex = targetStackInfo.isStackedByIndex;
         const stackStrategy = targetStackInfo.seriesModel.get('stackStrategy') || 'samesign';
 
+        // TODO: get correct value start from coordinate system info?
+        const valueStart = 0;
+
         // Should not write on raw data, because stack series model list changes
         // depending on legend selection.
         targetData.modify(dims, function (v0, v1, dataIndex) {
@@ -111,7 +114,7 @@ function calculateStack(stackInfoList: StackInfo[]) {
             }
 
             // If stackOver is NaN, chart view will render point on value start.
-            let stackedOver = NaN;
+            let stackedOver = idxInStack === 0 ? valueStart : NaN;
 
             for (let j = idxInStack - 1; j >= 0; j--) {
                 const stackInfo = stackInfoList[j];
@@ -140,6 +143,9 @@ function calculateStack(stackInfoList: StackInfo[]) {
                         sum = addSafe(sum, val);
                         stackedOver = val;
                         break;
+                    }
+                    else if (!isNaN(val)) {
+                        stackedOver = valueStart;
                     }
                 }
             }


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->



### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
